### PR TITLE
Исправление для pre

### DIFF
--- a/markdown.php
+++ b/markdown.php
@@ -1116,7 +1116,7 @@ class Markdown_Parser {
 
 	function doCodeBlocks($text) {
 	#
-	#	Process Markdown `<pre><code>` blocks.
+	#	Process Markdown `<pre>` blocks.
 	#
 		$text = preg_replace_callback('{
 				(?:\n\n|\A\n?)

--- a/markdown.php
+++ b/markdown.php
@@ -1141,7 +1141,7 @@ class Markdown_Parser {
 		# trim leading newlines and trailing newlines
 		$codeblock = preg_replace('/\A\n+|\n+\z/', '', $codeblock);
 
-		$codeblock = "<pre><code>$codeblock\n</code></pre>";
+		$codeblock = "<pre>$codeblock\n</pre>";
 		return "\n\n".$this->hashBlock($codeblock)."\n\n";
 	}
 


### PR DESCRIPTION
Помимо того, что оно хочет 8 пробелов вместо стандартных 4 (или еще более удобных ` ``` ` гитхаба), так в результате у меня оно выдает `<code>написанное_мной</code>`, где открывающий и закрывающий `code` — текст, видимый внутри `pre` (сам `pre` — нормальная нода) )))
Плагин стоит вместе с bbcode и это единственные включенные плагины )